### PR TITLE
Bugfix (#17)

### DIFF
--- a/clane/graph.py
+++ b/clane/graph.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import numpy as np
 import torch
 from torch.utils.data import Dataset
 
@@ -42,7 +43,7 @@ class Graph(Dataset):
 
         # Content Embeddings of the vertices, C.
         try:
-            self.C = torch.load(data_root.joinpath("C.npy"))
+            self.C = torch.from_numpy(np.load(data_root.joinpath("C.npy")))
         except FileNotFoundError:
             try:
                 self.C = torch.load(data_root.joinpath("C.pt"))


### PR DESCRIPTION
When a content embedding is given as a pickled np.ndarray,
load the pickled np.ndarray with np.load(),
and then load the np.ndarray as torch.Tensor.

Fixed #17