### PR TITLE
Make embedder can save embeddings for every iteration

### DIFF
--- a/clane/__main__.py
+++ b/clane/__main__.py
@@ -46,15 +46,22 @@ def embedding(args):
         similarity_measure=similarity_measure,
         **hparams["embedder"],
     )
-    embedder.iterate()
+    embedder.iterate(save_all=args.save_all)
 
     print("Saving the results.")
     if not args.output_root.exists():
         args.output_root.mkdir()
-    torch.save(
-        obj=g.Z,
-        f=args.output_root.joinpath('Z.pt')
-    )
+    if args.save_all:
+        for iter, history in enumerate(g.embedding_history):
+            torch.save(
+                obj=history,
+                f=args.output_root.joinpath(f'Z_{iter}.pt')
+            )
+    else:
+        torch.save(
+            obj=g.Z,
+            f=args.output_root.joinpath('Z.pt')
+        )
 
     print(f"The embeddings are stored in {args.output_root.joinpath('Z.pt').absolute()}.")
 
@@ -75,6 +82,10 @@ def main():
     embedding_parser.add_argument(
         "--config_file", type=Path,
         help="Path to the training configuration yaml file."
+    )
+    embedding_parser.add_argument(
+        "--save_all", action='store_true',
+        help="If true, it saves the embeddings for every iteration."
     )
     embedding_parser.set_defaults(func=embedding)
 

--- a/clane/embedder.py
+++ b/clane/embedder.py
@@ -18,12 +18,18 @@ class Embedder(object):
 
     def iterate(
         self,
+        save_all: bool = False,
     ) -> None:
 
         diff = Inf
 
+        if save_all:
+            self.graph.embedding_history = []
+
         while self.tolerence > 0:
             prior_Z = self.graph.Z.clone()
+            if save_all:
+                self.graph.embedding_history.append(prior_Z)
 
             for v in self.graph.V:
                 similaryties = [self.similarity_measure(v.z, edge.dst.z) for edge in self.graph.E if edge.src == v]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,10 @@ class TestCLI(unittest.TestCase):
             "--config_file", type=Path,
             help="Path to the training configuration yaml file."
         )
+        embedding_parser.add_argument(
+            "--save_all", action='store_true',
+            help="If true, it saves the embeddings for every iteration."
+        )
 
         self.args = parser.parse_args(args=[
             "train",
@@ -39,6 +43,11 @@ class TestCLI(unittest.TestCase):
         Z = torch.load(Path("./test_output/Z.pt"))
         self.assertEqual(Z.shape[0], 34)
         self.assertEqual(Z.shape[1], 64)
+
+    def test_cli_with_save_all(self):
+        self.args.save_all = True
+        embedding(self.args)
+        self.assertGreater(len(list(Path('./test_output').glob('./*_*.pt'))), 1)
 
     def tearDown(self) -> None:
         import shutil

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -1,5 +1,7 @@
 import unittest
 from pathlib import Path
+
+from numpy.lib.npyio import save
 from clane import similarity
 from clane.embedder import Embedder
 
@@ -24,3 +26,9 @@ class TestEmbedder(unittest.TestCase):
     def test_iterate_if_embeddings_are_updated(self):
         self.embedder.iterate()
         self.assertNotEqual((self.g.Z - self.g.C).sum(), 0)
+
+    def test_save_embedding_history(self):
+        self.embedder.iterate(save_all=True)
+
+        self.assertTrue(hasattr(self.g, "embedding_history"))
+        self.assertGreater(len(self.g.embedding_history), 1)


### PR DESCRIPTION
If '--save_all' is given as True, the embedder does:
1. create a new attribute 'embedding_history' to the Graph instance.
2. Initialize the 'embedding_history' as an empty list.
3. Append 'prior_Z' of the Graph instance to the list for every iteration.
